### PR TITLE
feat: add dark mode styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Demo: [https://minimalist-hugo.netlify.app/](https://minimalist-hugo.netlify.app
 - SEO optimized (Twitter cards, Facebook Open Graph, Schema.org)
 - Ultra fast
 - CSS is only 692B!
+- Dark mode support via `prefers-color-scheme`

--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -57,3 +57,21 @@ img {
 a, a:visited {
   color: initial;
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #111;
+    color: #eee;
+  }
+  pre,
+  code {
+    background: #333;
+  }
+  blockquote {
+    border-left-color: #333;
+  }
+  a,
+  a:visited {
+    color: #9cdcfe;
+  }
+}


### PR DESCRIPTION
## Summary
- add dark theme styling using `prefers-color-scheme`
- document dark mode support in README

## Testing
- `hugo` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688ead29d4b083238ca75294e4bc9acd